### PR TITLE
Checkbox and Radio

### DIFF
--- a/build.css
+++ b/build.css
@@ -4,3 +4,5 @@
 @import "css/blocks-notice.css";
 @import "css/blocks-select.css";
 @import "css/blocks-text-input.css";
+@import "css/checkbox-input";
+@import "css/checkbox-label";

--- a/build.css
+++ b/build.css
@@ -6,3 +6,5 @@
 @import "css/blocks-text-input.css";
 @import "css/checkbox-input";
 @import "css/checkbox-label";
+@import "css/radio-input";
+@import "css/radio-label";

--- a/css/checkbox-input.css
+++ b/css/checkbox-input.css
@@ -1,0 +1,6 @@
+.checkbox-input {
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  opacity: 0;
+}

--- a/css/checkbox-label.css
+++ b/css/checkbox-label.css
@@ -1,0 +1,48 @@
+.checkbox-label {
+  padding-left: 24px;
+  font-size: inherit;
+  position: relative;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+/* Box */
+.checkbox-label::before {
+  width: 16px;
+  height: 16px;
+  top: 1px;
+  left: 0;
+
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 3px;
+  background-color: inherit;
+
+  position: absolute;
+  content: "";
+}
+
+/* Check */
+.checkbox-label::after {
+  width: 5px;
+  height: 8px;
+  top: 4px;
+  left: 5px;
+
+  border-width: 2px;
+  border-style: solid;
+  border-right-color: black;
+  border-bottom-color: black;
+  border-left-width: 0;
+  border-top-width: 0;
+  transform: translateX(0.5px) rotate(45deg);
+  opacity: 0;
+
+  position: absolute;
+  content: "";
+}
+
+/* Focus */
+.checkbox-input:checked + .checkbox-label::after {
+  opacity: 1;
+}

--- a/css/radio-input.css
+++ b/css/radio-input.css
@@ -1,0 +1,6 @@
+.radio-input {
+  width: 16px;
+  height: 16px;
+  position: absolute;
+  opacity: 0;
+}

--- a/css/radio-label.css
+++ b/css/radio-label.css
@@ -1,0 +1,43 @@
+.radio-label {
+  padding-left: 24px;
+  font-size: inherit;
+  position: relative;
+  vertical-align: middle;
+  cursor: pointer;
+}
+
+/* Radio */
+.radio-label::before {
+  width: 16px;
+  height: 16px;
+  top: 1px;
+  left: 0;
+
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 50%;
+  background-color: inherit;
+
+  position: absolute;
+  content: "";
+}
+
+/* Dot */
+.radio-label::after {
+  width: 6px;
+  height: 6px;
+  top: 6px;
+  left: 5px;
+
+  background-color: black;
+  border-radius: 50%;
+  opacity: 0;
+
+  position: absolute;
+  content: "";
+}
+
+/* Focus */
+.radio-input:checked + .radio-label::after {
+  opacity: 1;
+}

--- a/index.html
+++ b/index.html
@@ -21,6 +21,8 @@
 
   <link rel="stylesheet" href="./css/checkbox-input.css">
   <link rel="stylesheet" href="./css/checkbox-label.css">
+  <link rel="stylesheet" href="./css/radio-input.css">
+  <link rel="stylesheet" href="./css/radio-label.css">
 
   <title>Blocks</title>
 </head>
@@ -145,11 +147,17 @@
   <br style="margin: 1em" />
 
   <h2>
-    <code>checkbox</code>
+    <code>checkbox and radio</code>
   </h2>
 
   <input id="checkbox1" type="checkbox" class="checkbox-input">
   <label for="checkbox1" class="checkbox-label">checkbox label text</label>
+
+  <br />
+  <br />
+
+  <input id="radio1" type="radio" class="radio-input">
+  <label for="radio1" class="radio-label">radio label text</label>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,9 @@
   <link rel="stylesheet" href="./css/blocks-select.css">
   <link rel="stylesheet" href="./css/blocks-text-input.css">
 
+  <link rel="stylesheet" href="./css/checkbox-input.css">
+  <link rel="stylesheet" href="./css/checkbox-label.css">
+
   <title>Blocks</title>
 </head>
 
@@ -140,6 +143,13 @@
   <button type="button" class="blocks-action blocks-6">button blocks-6</button>
 
   <br style="margin: 1em" />
+
+  <h2>
+    <code>checkbox</code>
+  </h2>
+
+  <input id="checkbox1" type="checkbox" class="checkbox-input">
+  <label for="checkbox1" class="checkbox-label">checkbox label text</label>
 </body>
 
 </html>


### PR DESCRIPTION
Add checkbox and radio with barebone styling.

Checkboxes and radios are sized as `16x16` because we determined that that should be the minimum size, however, they otherwise do not follow the `block-*` scale for sizing (e.g. heights, font sizes)

```html
<input id="checkbox1" type="checkbox" class="checkbox-input">
<label for="checkbox1" class="checkbox-label">checkbox label text</label>

<input id="radio1" type="radio" class="radio-input">
<label for="radio1" class="radio-label">radio label text</label>
```

![image](https://user-images.githubusercontent.com/359871/34055376-83e1c282-e194-11e7-9cda-131a0fe56313.png)

## Theme-ing

Below is an example to theme the checkbox and radio elements with minimal CSS. This is not included in the src; however, should be documented.

![image](https://user-images.githubusercontent.com/359871/34055485-f8a0a75a-e194-11e7-99a6-23d034f1b18e.png)

### Checkbox
```css
/* Box */
.checkbox-label::before {
  background-color: lightgray;
  border-color: gray;
}
/* Checkmark */
.checkbox-label::after {
  border-color: white;
}
/* Checked Box */
.checkbox-input:checked + .checkbox-label::before {
  background-color: seagreen;
  border-color: darkgreen;
}
/* Focused Box */
.checkbox-input:focus + .checkbox-label::before {
  box-shadow: 0 0 3px 1px lightskyblue;
}
```

### Radio
```css
/* Radio */
.radio-label::before {
  background-color: lightgray;
  border-color: gray;
}
/* Dot */
.radio-label::after {
  background-color: white;
}
/* Selected Radio */
.radio-input:checked + .radio-label::before {
  background-color: dodgerblue;
  border-color: royalblue;
}
/* Focused Radio */
.radio-input:focus + .radio-label::before {
  box-shadow: 0 0 3px 1px lightskyblue;
}
```